### PR TITLE
Adding lazy-cache to require dependencies on-demand

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-module.exports = {
-  series: require('./lib/series'),
-  parallel: require('./lib/parallel'),
-  settleSeries: require('./lib/settleSeries'),
-  settleParallel: require('./lib/settleParallel')
-};
+var lazy = require('lazy-cache')(require);
+lazy('./lib/series', 'series');
+lazy('./lib/parallel', 'parallel');
+lazy('./lib/settleSeries', 'settleSeries');
+lazy('./lib/settleParallel', 'settleParallel');
+
+module.exports = lazy;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,8 +1,12 @@
 'use strict';
 
+var lazy = require('lazy-cache')(require);
 var assert = require('assert');
 
-var _ = require('lodash');
+lazy('lodash', '_');
+lazy('async-done');
+lazy('now-and-later');
+lazy('async-settle');
 
 function getExtensions(lastArg){
   if(typeof lastArg !== 'function'){
@@ -11,24 +15,24 @@ function getExtensions(lastArg){
 }
 
 function buildOnSettled(done){
-  done = done || _.noop;
+  done = done || lazy._.noop;
 
   function onSettled(error, result){
     if(error){
       return done(error, null);
     }
 
-    var settledErrors = _.where(result, { state: 'error' });
-    var settledResults = _.where(result, { state: 'success' });
+    var settledErrors = lazy._.where(result, { state: 'error' });
+    var settledResults = lazy._.where(result, { state: 'success' });
 
     var errors = null;
     if(settledErrors.length){
-      errors = _.pluck(settledErrors, 'value');
+      errors = lazy._.pluck(settledErrors, 'value');
     }
 
     var results = null;
     if(settledResults.length){
-      results = _.pluck(settledResults, 'value');
+      results = lazy._.pluck(settledResults, 'value');
     }
 
     done(errors, results);
@@ -38,13 +42,13 @@ function buildOnSettled(done){
 }
 
 function verifyArguments(args){
-  args = _.flatten(args);
+  args = lazy._.flatten(args);
   var lastIdx = args.length - 1;
 
   assert.ok(args.length, 'A set of functions to combine is required');
 
-  _.forEach(args, function(arg, argIdx){
-    var isFunction = _.isFunction(arg);
+  lazy._.forEach(args, function(arg, argIdx){
+    var isFunction = lazy._.isFunction(arg);
     if(isFunction){
       return;
     }
@@ -61,8 +65,8 @@ function verifyArguments(args){
   return args;
 }
 
-module.exports = {
-  getExtensions: getExtensions,
-  onSettled: buildOnSettled,
-  verifyArguments: verifyArguments
-};
+lazy.getExtensions = getExtensions;
+lazy.onSettled = buildOnSettled;
+lazy.verifyArguments = verifyArguments;
+
+module.exports = lazy;

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -1,22 +1,18 @@
 'use strict';
 
-var _ = require('lodash');
-var asyncDone = require('async-done');
-var nowAndLater = require('now-and-later');
-
 var helpers = require('./helpers');
 
 function buildParallel(){
   var args = helpers.verifyArguments(arguments);
 
-  var extensions = helpers.getExtensions(_.last(args));
+  var extensions = helpers.getExtensions(helpers._.last(args));
 
   if(extensions){
-    args = _.initial(args);
+    args = helpers._.initial(args);
   }
 
   function parallel(done){
-    nowAndLater.map(args, asyncDone, extensions, done);
+    helpers.nowAndLater.map(args, helpers.asyncDone, extensions, done);
   }
 
   return parallel;

--- a/lib/series.js
+++ b/lib/series.js
@@ -1,22 +1,18 @@
 'use strict';
 
-var _ = require('lodash');
-var asyncDone = require('async-done');
-var nowAndLater = require('now-and-later');
-
 var helpers = require('./helpers');
 
 function buildSeries(){
   var args = helpers.verifyArguments(arguments);
 
-  var extensions = helpers.getExtensions(_.last(args));
+  var extensions = helpers.getExtensions(helpers._.last(args));
 
   if(extensions){
-    args = _.initial(args);
+    args = helpers._.initial(args);
   }
 
   function series(done){
-    nowAndLater.mapSeries(args, asyncDone, extensions, done);
+    helpers.nowAndLater.mapSeries(args, helpers.asyncDone, extensions, done);
   }
 
   return series;

--- a/lib/settleParallel.js
+++ b/lib/settleParallel.js
@@ -1,22 +1,18 @@
 'use strict';
 
-var _ = require('lodash');
-var asyncSettle = require('async-settle');
-var nowAndLater = require('now-and-later');
-
 var helpers = require('./helpers');
 
 function buildSettleParallel(){
   var args = helpers.verifyArguments(arguments);
 
-  var extensions = helpers.getExtensions(_.last(args));
+  var extensions = helpers.getExtensions(helpers._.last(args));
 
   if(extensions){
-    args = _.initial(args);
+    args = helpers._.initial(args);
   }
 
   function settleParallel(done){
-    nowAndLater.map(args, asyncSettle, extensions, helpers.onSettled(done));
+    helpers.nowAndLater.map(args, helpers.asyncSettle, extensions, helpers.onSettled(done));
   }
 
   return settleParallel;

--- a/lib/settleSeries.js
+++ b/lib/settleSeries.js
@@ -1,22 +1,18 @@
 'use strict';
 
-var _ = require('lodash');
-var asyncSettle = require('async-settle');
-var nowAndLater = require('now-and-later');
-
 var helpers = require('./helpers');
 
 function buildSettleSeries(){
   var args = helpers.verifyArguments(arguments);
 
-  var extensions = helpers.getExtensions(_.last(args));
+  var extensions = helpers.getExtensions(helpers._.last(args));
 
   if(extensions){
-    args = _.initial(args);
+    args = helpers._.initial(args);
   }
 
   function settleSeries(done){
-    nowAndLater.mapSeries(args, asyncSettle, extensions, helpers.onSettled(done));
+    helpers.nowAndLater.mapSeries(args, helpers.asyncSettle, extensions, helpers.onSettled(done));
   }
 
   return settleSeries;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "async-done": "^1.0.0",
     "async-settle": "^0.2.0",
+    "lazy-cache": "^0.2.3",
     "lodash": "^3.0.0",
     "now-and-later": "0.0.6"
   },


### PR DESCRIPTION
I'm using bach for things where some of the dependencies might not be needed.
This PR uses [lazy-cache](https://github.com/jonschlinkert/lazy-cache) to load dependencies on-demand, whichmeans that some dependencies may be completely skipped if methods like `series`, `settledSeries`, and `settledParallel` aren't used.